### PR TITLE
Fix for specifying a nimbus version other than latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name                           | Default Value                      |  Description                                                                                                        |
 |--------------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | `nimbus_version`               | latest                             | Version of nimbus to install and run. Use "latest" to automatically fetch the latest version.                       |
+| `nimbus_git_hash`              |                                   | Git hash of the specific version. Required when `nimbus_version` is not "latest".                                   |
 | `nimbus_user`                | nimbus                         | nimbus user                                                                                                   |
 | `nimbus_group`               | nimbus                         | nimbus group                                                                                                  |
 | `nimbus_base_dir`            | /opt/nimbus                    | Path to install to                                                                                           |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,10 +3,8 @@
 nimbus_user: nimbus
 nimbus_group: "{{ nimbus_user }}"
 nimbus_architecture: "amd64"
-# Version to install - linux only!
-# https://github.com/status-im/nimbus-eth2/releases/download/v23.6.1/nimbus-eth2_Linux_amd64_23.6.1_187e1a06.tar.gz
 nimbus_version: "latest"
-nimbus_download_url: "{{ nimbus_version == 'latest' | ternary(nimbus_download_url, 'https://github.com/status-im/nimbus-eth2/releases/download/' + nimbus_version + '/nimbus-eth2_Linux_' + nimbus_architecture + '_' + nimbus_version[1:] + '_' + nimbus_git_hash + '.tar.gz') }}"
+nimbus_git_hash: ""  # This will be set automatically for "latest", or needs to be provided for specific versions
 
 # Directory paths
 nimbus_base_dir: "/opt/nimbus"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,13 @@
   include_tasks: "get_latest_version.yml"
   when: nimbus_version == "latest"
 
+- name: Set download URL for specific version
+  set_fact:
+  # Version to install - linux only!
+ # https://github.com/status-im/nimbus-eth2/releases/download/v23.6.1/nimbus-eth2_Linux_amd64_23.6.1_187e1a06.tar.gz
+    nimbus_download_url: "https://github.com/status-im/nimbus-eth2/releases/download/{{ nimbus_version }}/nimbus-eth2_Linux_{{ nimbus_architecture }}_{{ nimbus_version[1:] }}_{{ nimbus_git_hash }}.tar.gz"
+  when: nimbus_version != "latest"
+
 - name: Get IP address to bind to if not provided
   include_tasks: "network.yml"
   when: not nimbus_host_ip


### PR DESCRIPTION
Move logic from default -> tasks to avoid stackoverflow

Tested with CL_CLIENT_VERSION = "v24.5.1_d2a07514"
https://jenkins.dev.protocols.consensys.net/job/Besu/job/elc-create-Default/3316/parameters/

Tested with CL_CLIENT_VERSION = "latest"
https://jenkins.dev.protocols.consensys.net/job/Besu/job/elc-create-Default/3317/parameters/
