### PR TITLE
use ethpandaops url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,7 +50,7 @@ nimbus_network: mainnet
 nimbus_host_ip: ""
 nimbus_log_level: INFO
 nimbus_execution_urls: "http://127.0.0.1:8551"
-nimbus_checkpoint_sync_url: "https://beaconstate-{{nimbus_network}}.chainsafe.io"
+nimbus_checkpoint_sync_url: "https://checkpoint-sync.{{nimbus_network}}.ethpandaops.io"
 nimbus_default_fee_recipient: ""
 
 #p2p


### PR DESCRIPTION
seems to be more reliable for holesky but not sure if we want to make this change permanent

```
INF 2025-10-02 05:00:40.233+00:00 Obtaining genesis state                    topics="beacnde" sourceUrl=https://github.com/status-im/nimbus-eth2/releases/download/v23.9.1/holesky-genesis.ssz.sz
NTC 2025-10-02 05:00:45.496+00:00 Starting trusted node sync                 databaseDir=/data/nimbus/db backfill=false reindex=false restUrl=https://beaconstate-holesky.chainsafe.io/ syncTarget=finalized
NTC 2025-10-02 05:00:45.525+00:00 Downloading checkpoint state               restUrl=https://beaconstate-holesky.chainsafe.io/ syncTarget=finalized stateId=finalized
ERR 2025-10-02 05:00:45.941+00:00 Unable to download checkpoint state        error="Error response (500) [no finality known]" restUrl=https://beaconstate-holesky.chainsafe.io/ syncTarget=finalized stateId=finalized
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change default `nimbus_checkpoint_sync_url` to `https://checkpoint-sync.{{nimbus_network}}.ethpandaops.io`.
> 
> - **Config**:
>   - Update default `nimbus_checkpoint_sync_url` from `https://beaconstate-{{nimbus_network}}.chainsafe.io` to `https://checkpoint-sync.{{nimbus_network}}.ethpandaops.io`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f6c3831756666a01e99be9aa80a1f005a9b80df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->