### PR TITLE
Revert "use ethpandaops url"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,7 +50,7 @@ nimbus_network: mainnet
 nimbus_host_ip: ""
 nimbus_log_level: INFO
 nimbus_execution_urls: "http://127.0.0.1:8551"
-nimbus_checkpoint_sync_url: "https://checkpoint-sync.{{nimbus_network}}.ethpandaops.io"
+nimbus_checkpoint_sync_url: "https://beaconstate-{{nimbus_network}}.chainsafe.io"
 nimbus_default_fee_recipient: ""
 
 #p2p


### PR DESCRIPTION
Reverts Consensys/ansible-role-nimbus#11 - this breaks mainnet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Changes `nimbus_checkpoint_sync_url` default from ethpandaops to `https://beaconstate-{{nimbus_network}}.chainsafe.io` in `defaults/main.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04d7dba2bbfbc2940c7188743a199243e691e7ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->